### PR TITLE
Adding `description` and `url` to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ from setuptools import setup
 setup(
     name='simuvex',
     version='4.5.10.15',
+    description=' A symbolic execution engine for the VEX IR',
+    url='https://github.com/angr/simuvex',
     packages=['simuvex', 'simuvex.plugins', 'simuvex.storage', 'simuvex.vex', 'simuvex.vex.statements', 'simuvex.vex.expressions', 'simuvex.procedures', 'simuvex.procedures.cgc', 'simuvex.procedures.ld-linux-x86-64___so___2', 'simuvex.procedures.testing', 'simuvex.procedures.stubs', 'simuvex.procedures.syscalls', 'simuvex.procedures.ld-uClibc___so___0', 'simuvex.procedures.libc___so___6'],
     install_requires=[
         'dpkt-fix',


### PR DESCRIPTION
Adding `description` and `url` to setup.py. This allows `pypi` to automatically pick it up.