### PR TITLE
Implement '%x' parsing for format strings

### DIFF
--- a/simuvex/s_format.py
+++ b/simuvex/s_format.py
@@ -149,11 +149,12 @@ class FormatString(object):
                 else:
 
                     # XXX: atoi only supports strings of one byte
-                    if fmt_spec.spec_type == 'd' or fmt_spec.spec_type == 'u':
-                        status, i, _ = self.parser._sim_atoi_inner(position, region)
+                    if fmt_spec.spec_type in ['d', 'u', 'x']:
+                        base = 16 if fmt_spec.spec_type == 'x' else 10
+                        status, i, num_bytes = self.parser._sim_atoi_inner(position, region, base=base, read_length=fmt_spec.length_spec)
                         # increase failed count if we were unable to parse it
                         failed = self.parser.state.se.If(status, failed, failed + 1)
-                        position += 1
+                        position += num_bytes
                     elif fmt_spec.spec_type == 'c':
                         i = region.load(position, 1)
                         i = i.zero_extend(bits - 8)
@@ -161,7 +162,8 @@ class FormatString(object):
                     else:
                         raise SimProcedureError("unsupported format spec '%s' in interpret" % fmt_spec.spec_type)
 
-                    self.parser.state.memory.store(dest, i, endness=self.parser.state.arch.memory_endness)
+                    i = self.parser.state.se.Extract(fmt_spec.size*8-1, 0, i)
+                    self.parser.state.memory.store(dest, i, size=fmt_spec.size, endness=self.parser.state.arch.memory_endness)
 
                 argpos += 1
 
@@ -371,14 +373,14 @@ class FormatParser(SimProcedure):
 
         return FormatString(self, components)
 
-    def _sim_atoi_inner(self, str_addr, region):
+    def _sim_atoi_inner(self, str_addr, region, base=10, read_length=None):
         """
         Return the result of invoking the atoi simprocedure on str_addr
         """
 
         strtol = simuvex.SimProcedures['libc.so.6']['strtol']
 
-        return strtol.strtol_inner(str_addr, self.state, self.state.memory, 10, True)
+        return strtol.strtol_inner(str_addr, self.state, self.state.memory, base, True, read_length=read_length)
 
 
     def _sim_strlen(self, str_addr):


### PR DESCRIPTION
• Adds `read_length` argument to strtol (can be used to specify a max length for decoding)
• Use the format spec size when writing
• Fix an off-by-one error in hex decoding (previously decoded `g` as `16`)

Test cases provided in [PR 53 in angr](https://github.com/angr/angr/pull/53).