### PR TITLE
Quick fix for the API mismatch between recv and posix.read

### DIFF
--- a/simuvex/procedures/libc___so___6/recv.py
+++ b/simuvex/procedures/libc___so___6/recv.py
@@ -8,6 +8,5 @@ class recv(simuvex.SimProcedure):
     #pylint:disable=arguments-differ
 
     def run(self, fd, dst, length):
-        data = self.state.posix.read(fd, self.state.se.any_int(length))
-        self.state.memory.store(dst, data)
-        return length
+        bytes_recvd = self.state.posix.read(fd, dst, self.state.se.any_int(length))
+        return bytes_recvd


### PR DESCRIPTION
Quick fix for the API used in `recv()` vs what is used with `posix.read()`