### PR TITLE
Implement SimSockets by having 2 SimFiles for send/recv

### DIFF
--- a/simuvex/plugins/posix.py
+++ b/simuvex/plugins/posix.py
@@ -261,7 +261,7 @@ class SimStateSystem(SimStatePlugin):
         return None
 
     def copy(self):
-        sockets = self.sockets
+        sockets = { fd:s.copy() for fd,s in self.sockets.iteritems() }
         files = { fd:f.copy() for fd,f in self.files.iteritems() }
         return SimStateSystem(initialize=False, files=files, concrete_fs=self.concrete_fs, chroot=self.chroot, sockets=sockets, pcap_backer=self.pcap, argv=self.argv, argc=self.argc, environ=self.environ, auxv=self.auxv, tls_modules=self.tls_modules, fs=self.fs)
 

--- a/simuvex/procedures/libc___so___6/accept.py
+++ b/simuvex/procedures/libc___so___6/accept.py
@@ -13,7 +13,7 @@ class accept(simuvex.SimProcedure):
         ## this is the name for now
 
         #this is the mode for now
-        sockaddr_struct_ptr = self.arg(1)
+        # sockaddr_struct_ptr = self.arg(1)
 
         #socklen_t_addrlen = self.arg(2)
         ## TODO handle mode if flags == O_CREAT
@@ -22,12 +22,12 @@ class accept(simuvex.SimProcedure):
         #flags = 'wr'
 
         # TODO handle errors and symbolic path
-        key = self.state.posix.open(sockfd, sockaddr_struct_ptr)
+        key = self.state.posix.add_socket()
         #add this socket to the SimStateSystem list of sockets
-        self.state.posix.add_socket(key)
+        # self.state.posix.add_socket(key)
 
-        #should back the SimFile associated with this key by the first pcap on the pcap queue
-        #and then transfer that pcap to the list/queue of used_pcaps
-        self.state.posix.back_with_pcap(key)
+        # should back the SimFile associated with this key by the first pcap on the pcap queue
+        # and then transfer that pcap to the list/queue of used_pcaps
+        # self.state.posix.back_with_pcap(key)
         return key
 

--- a/simuvex/procedures/libc___so___6/recv.py
+++ b/simuvex/procedures/libc___so___6/recv.py
@@ -1,4 +1,7 @@
 import simuvex
+import logging
+
+logging.getLogger('simuvex.plugins.posix.sockets')
 
 ######################################
 # recv
@@ -8,5 +11,8 @@ class recv(simuvex.SimProcedure):
     #pylint:disable=arguments-differ
 
     def run(self, fd, dst, length):
-        bytes_recvd = self.state.posix.read(fd, dst, self.state.se.any_int(length))
+        fd = int(self.state.se.any_int(fd))
+        recv_fd = self.state.posix.sockets[fd].recv_fd
+        bytes_recvd = self.state.posix.read(recv_fd, dst, self.state.se.any_int(length))
+
         return bytes_recvd

--- a/simuvex/procedures/libc___so___6/send.py
+++ b/simuvex/procedures/libc___so___6/send.py
@@ -1,4 +1,7 @@
 import simuvex
+import logging
+
+l = logging.getLogger('simuvex.plugins.posix.sockets')
 
 ######################################
 # send
@@ -8,6 +11,9 @@ class send(simuvex.SimProcedure):
     #pylint:disable=arguments-differ
 
     def run(self, fd, src, length):
+        fd = int(self.state.se.any_int(fd))
+        send_fd = self.state.posix.sockets[fd].send_fd
         data = self.state.memory.load(src, length)
-        length = self.state.posix.write(fd, data, length)
+        length = self.state.posix.write(send_fd, data, length)
         return length
+

--- a/simuvex/procedures/libc___so___6/socket_.py
+++ b/simuvex/procedures/libc___so___6/socket_.py
@@ -9,13 +9,13 @@ class socket(simuvex.SimProcedure):
 
     def run(self, sim_sock_type):
         # TODO: Handling parameters
-
+        
         sock_type = self.state.se.any_int(sim_sock_type)
         # TODO handle errors and symbolic path
-        fd = self.state.posix.open("socket_socket", "rw")
+        fd = self.state.posix.add_socket()
 
         #if type is 0, it's UDP so create a socket for it, if not then it's 1 and we create a socket later in accept()
         if sock_type is 0:
             self.state.posix.back_with_pcap(fd)
-        self.state.posix.add_socket(fd)
+
         return fd

--- a/simuvex/storage/socket.py
+++ b/simuvex/storage/socket.py
@@ -19,6 +19,9 @@ class SimSocket():
     def send_fd(self):
         return self.send_fd
 
+    def copy(self):
+        return SimSocket(self.fd, self.send_fd, self.recv_fd)
+
     def __str__(self):
         return '<{} fd {} recv {} send {}>'.format(self.__class__.__name__,
                                                    self.fd,

--- a/simuvex/storage/socket.py
+++ b/simuvex/storage/socket.py
@@ -1,0 +1,26 @@
+from ..storage.file import SimFile
+from ..plugins.plugin import SimStatePlugin
+
+class SimSocket():
+    def __init__(self, new_fd, new_send_fd, new_recv_fd):
+        self.fd = new_fd
+        self.send_fd = new_send_fd
+        self.recv_fd = new_recv_fd
+
+    @property
+    def fd(self):
+        return self.fd
+
+    @property
+    def recv_fd(self):
+        return self.recv_fd
+
+    @property
+    def send_fd(self):
+        return self.send_fd
+
+    def __str__(self):
+        return '<{} fd {} recv {} send {}>'.format(self.__class__.__name__,
+                                                   self.fd,
+                                                   self.recv_fd,
+                                                   self.send_fd)


### PR DESCRIPTION
Replace each socket fd with 2 SimFiles, one for send and one for recv.

`posix.sockets` still contains a list of current sockets
`posix.dumps` now can take a `SimSocket` and returns a `SocketResult` namedtuple that contains the results of concretizing the two SimFiles for the socket.

i.e.

```
for socket_fd, curr_socket in f.state.posix.sockets.iteritems():
    result = f.state.posix.dumps(curr_socket)
    # result.send contains concretized send
    # result.recv contains concretized recv
```

There is also a test case for sockets included as well.
