### PR TITLE
Implement pc_actions_ROL and corresponding tests

### DIFF
--- a/simuvex/vex/ccall.py
+++ b/simuvex/vex/ccall.py
@@ -372,9 +372,15 @@ def pc_actions_SHR(state, nbits, remaining, shifted, cc_ndep, platform=None):
     of = (remaining[0] ^ shifted[0])[0]
     return pc_make_rdata(data[platform]['size'], cf, pf, af, zf, sf, of, platform=platform)
 
-def pc_actions_ROL(*args, **kwargs):
-    l.error("Unsupported flag action ROL")
-    raise SimCCallError("Unsupported flag action. Please implement or bug Yan.")
+def pc_actions_ROL(state, nbits, res, _, cc_ndep, platform=None):
+    cf = res[0]
+    pf = (cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_P'])[data[platform]['CondBitOffsets']['G_CC_SHIFT_P']]
+    af = (cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_A'])[data[platform]['CondBitOffsets']['G_CC_SHIFT_A']]
+    zf = (cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_Z'])[data[platform]['CondBitOffsets']['G_CC_SHIFT_Z']]
+    sf = (cc_ndep & data[platform]['CondBitMasks']['G_CC_MASK_S'])[data[platform]['CondBitOffsets']['G_CC_SHIFT_S']]
+    of = (state.se.LShR(res, nbits-1) ^ res)[0]
+    return pc_make_rdata(data[platform]['size'], cf, pf, af, zf, sf, of, platform=platform)
+    
 def pc_actions_ROR(*args, **kwargs):
     l.error("Unsupported flag action ROR")
     raise SimCCallError("Unsupported flag action. Please implement or bug Yan.")

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -56,6 +56,31 @@ def test_ccall():
     nose.tools.assert_true(s.se.is_true(sf == 0))
     nose.tools.assert_true(s.se.is_true(of == 0))
 
+    l.debug("Testing pc_actions_ROL")
+    l.debug("(8-bit) ROL 1 1...")
+    arg_l = s.se.BVV(1, 8)
+    arg_r = s.se.BVV(1, 8)
+    oldflags = s.se.BVV(0, 8) 
+    cf, pf, af, zf, sf, of = s_ccall.pc_actions_ROL(s, 8, arg_l, arg_r, oldflags, platform='AMD64')
+    nose.tools.assert_true(s.se.is_true(cf == 1))
+    nose.tools.assert_true(s.se.is_true(pf == 0))
+    nose.tools.assert_true(s.se.is_true(af == 0))
+    nose.tools.assert_true(s.se.is_true(zf == 0))
+    nose.tools.assert_true(s.se.is_true(sf == 0))
+    nose.tools.assert_true(s.se.is_true(of == 1))
+
+    l.debug("(32-bit) ROL (-1) (-2)...")
+    arg_l = s.se.BVV(-1, 32)
+    arg_r = s.se.BVV(-2, 32)
+    oldflags = s.se.BVV(0, 32)
+    cf, pf, af, zf, sf, of = s_ccall.pc_actions_ROL(s, 32, arg_l, arg_r, oldflags, platform='AMD64')
+    nose.tools.assert_true(s.se.is_true(cf == 1))
+    nose.tools.assert_true(s.se.is_true(pf == 0))
+    nose.tools.assert_true(s.se.is_true(af == 0))
+    nose.tools.assert_true(s.se.is_true(zf == 0))
+    nose.tools.assert_true(s.se.is_true(sf == 0))
+    nose.tools.assert_true(s.se.is_true(of == 0))    
+
 def test_some_vector_ops():
     from simuvex.vex.irop import translate
 


### PR DESCRIPTION
This PR implements the function `pc_actions_ROL` in simuvex/vex/ccall.py and the corresponding tests in `function test_ccall()` in file tests/test_vex.py as discussed in #13 