### PR TITLE
Update comments and reformatting.

### DIFF
--- a/simuvex/plugins/scratch.py
+++ b/simuvex/plugins/scratch.py
@@ -54,9 +54,9 @@ class SimStateScratch(SimStatePlugin):
         """
         Returns the Claripy expression of a VEX temp value.
 
-        @param tmp: the number of the tmp
-        @param simplify: simplify the tmp before returning it
-        @returns a Claripy expression of the tmp
+        :param tmp: the number of the tmp
+        :param simplify: simplify the tmp before returning it
+        :returns: a Claripy expression of the tmp
         """
         self.state._inspect('tmp_read', BP_BEFORE, tmp_read_num=tmp)
         v = self.temps[tmp]
@@ -67,8 +67,8 @@ class SimStateScratch(SimStatePlugin):
         """
         Stores a Claripy expression in a VEX temp value.
 
-        @param tmp: the number of the tmp
-        @param content: a Claripy expression of the content
+        :param tmp: the number of the tmp
+        :param content: a Claripy expression of the content
         """
         self.state._inspect('tmp_write', BP_BEFORE, tmp_write_num=tmp, tmp_write_expr=content)
         tmp = self.state._inspect_getattr('tmp_write_num', tmp)

--- a/simuvex/plugins/symbolic_memory.py
+++ b/simuvex/plugins/symbolic_memory.py
@@ -427,13 +427,13 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         """
         Concretizes an address meant for writing.
 
-            :param addr: an expression for the address
-            :param strategy: the strategy to use for concretization
-            :param limit: how many concrete values to limit the concretization to
-            :param approx_limit: how many concrete values to limit the concretization to,
-                                 if an approximation backend can be used for this value.
+            :param addr:            An expression for the address.
+            :param strategy:        The strategy to use for concretization,
+            :param limit:           How many concrete values to limit the concretization to.
+            :param approx_limit:    How many concrete values to limit the concretization to, if an approximation backend
+                                    can be used for this value.
 
-            @returns a list of concrete addresses
+            :returns:               A list of concrete addresses.
         """
 
         if isinstance(addr, (int, long)):
@@ -995,10 +995,10 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
 
     def changed_bytes(self, other):
         """
-        Gets the set of changed bytes between self and other.
+        Gets the set of changed bytes between self and `other`.
 
-        :param other: the other SimSymbolicMemory
-        @returns a set of differing bytes
+        :param other:   The other :class:`SimSymbolicMemory`.
+        :returns:       A set of differing bytes
         """
         return self.mem.changed_bytes(other.mem)
 
@@ -1006,9 +1006,9 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         """
         Replaces all instances of expression old with expression new.
 
-            :param old: a claripy expression. Must contain at least one named variable (to make
-                        to make it possible to use the name index for speedup)
-            :param new: the new variable to replace it with
+        :param old: A claripy expression. Must contain at least one named variable (to make
+                    to make it possible to use the name index for speedup)
+        :param new: The new variable to replace it with
         """
 
         return self.mem.replace_all(old, new)
@@ -1016,14 +1016,14 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
     def addrs_for_name(self, n):
         """
         Returns addresses that contain expressions that contain a variable
-        named n.
+        named `n`.
         """
         return self.mem.addrs_for_name(n)
 
     def addrs_for_hash(self, h):
         """
         Returns addresses that contain expressions that contain a variable
-        with the hash of h.
+        with the hash of `h`.
         """
         return self.mem.addrs_for_hash(h)
 
@@ -1032,9 +1032,9 @@ class SimSymbolicMemory(SimMemory): #pylint:disable=abstract-method
         Replaces the memory object 'old' with a new memory object containing
         'new_content'.
 
-            :param old: a SimMemoryObject (i.e., one from memory_objects_for_hash() or
-                        memory_objects_for_name())
-            :param new_content: the content (claripy expression) for the new memory object
+        :param old:         A SimMemoryObject (i.e., one from memory_objects_for_hash() or
+                            memory_objects_for_name())
+        :param new_content: the content (claripy expression) for the new memory object
         """
         return self.mem.replace_memory_object(old, new_content)
 

--- a/simuvex/s_run.py
+++ b/simuvex/s_run.py
@@ -6,6 +6,7 @@ import claripy
 import simuvex.s_options as o
 from claripy.ast.bv import BV
 
+
 class SimRun(object):
     def __init__(self, state, addr=None, inline=False, custom_name=None):
         # The address of this SimRun

--- a/simuvex/vex/irsb.py
+++ b/simuvex/vex/irsb.py
@@ -10,14 +10,18 @@ l = logging.getLogger("simuvex.vex.irsb")
 
 import pyvex
 from ..s_run import SimRun
-#import vexecutor
+
 
 class IMark(object):
+    """
+    An IMark is an IR statement that indicates the address and length of the original instruction.
+    """
     def __init__(self, i):
         self.addr = i.addr
         self.len = i.len
 
 #pylint:disable=unidiomatic-typecheck
+
 
 class SimIRSB(SimRun):
     """
@@ -147,11 +151,10 @@ class SimIRSB(SimRun):
 
         for exit_state in all_successors:
             if o.CALLLESS in self.state.options and exit_state.scratch.jumpkind == "Ijk_Call":
-                exit_state.registers.store(exit_state.arch.ret_offset, exit_state.se.Unconstrained('fake_ret_value', exit_state.arch.bits))
-
+                exit_state.registers.store(exit_state.arch.ret_offset,
+                                           exit_state.se.Unconstrained('fake_ret_value', exit_state.arch.bits))
                 exit_state.scratch.target = exit_state.se.BVV(self.addr + self.irsb.size, exit_state.arch.bits)
                 exit_state.scratch.jumpkind = "Ijk_Ret"
-
                 exit_state.regs.ip = exit_state.scratch.target
 
             elif o.DO_RET_EMULATION in exit_state.options and exit_state.scratch.jumpkind == "Ijk_Call":
@@ -247,8 +250,10 @@ class SimIRSB(SimRun):
                 state.scratch.temps[n] = self.state.se.Unconstrained('t%d_%s' % (n, self.id), size_bits(t))
             l.debug("%s prepared %d symbolic temps.", len(state.scratch.temps), self)
 
-    # Returns a list of instructions that are part of this block.
     def imark_addrs(self):
+        """
+        Returns a list of instructions that are part of this block.
+        """
         return [ i.addr for i in self.irsb.statements if type(i) == pyvex.IRStmt.IMark ]
 
     def reanalyze(self, mode=None, new_state=None, irsb_id=None, whitelist=None):


### PR DESCRIPTION
Mostly reformatting, the only added content is the definition of IMark (did I get it right?).

Also, PEP8 recommends 2 white lines before class definitions. If we would rather keep the formatting as it is I can modify my code style config so that it stops complaining about it.