### PR TITLE
Added tmp write SimActions for Vex CAS statement

### DIFF
--- a/simuvex/vex/statements/cas.py
+++ b/simuvex/vex/statements/cas.py
@@ -1,6 +1,5 @@
 from . import SimIRStmt
 
-# TODO: tmp write SimActions
 # TODO: mem read SimActions
 
 class SimIRStmt_CAS(SimIRStmt):
@@ -19,8 +18,8 @@ class SimIRStmt_CAS(SimIRStmt):
             # read the old values
             old_cnt = self.state.memory.load(addr.expr, len(expd_lo.expr)*2/8, endness=self.stmt.endness)
             old_hi, old_lo = old_cnt.chop(bits=len(expd_lo))
-            self.state.scratch.store_tmp(self.stmt.oldLo, old_lo)
-            self.state.scratch.store_tmp(self.stmt.oldHi, old_hi)
+            self._write_tmp(self.stmt.oldLo, old_lo, old_lo.size(), None, None)
+            self._write_tmp(self.stmt.oldHi, old_hi, old_hi.size(), None, None)
 
             # the write data
             data_lo = self._translate_expr(self.stmt.dataLo)
@@ -50,7 +49,7 @@ class SimIRStmt_CAS(SimIRStmt):
 
             # read the old values
             old_lo = self.state.memory.load(addr.expr, len(expd_lo.expr)/8, endness=self.stmt.endness)
-            self.state.scratch.store_tmp(self.stmt.oldLo, old_lo)
+            self._write_tmp(self.stmt.oldLo, old_lo, old_lo.size(), None, None)
 
             # the write data
             data = self._translate_expr(self.stmt.dataLo)


### PR DESCRIPTION
Hey guys,

When I compile a 32-bit Windows exe with mingw, the following code is produced for the function `InterlockedCompareExchange`:
```
0x4027c0 mov eax, DWORD PTR [esp+0xc]
0x4027c4 mov edx, DWORD PTR [esp+0x8]
0x4027c8 mov ecx, DWORD PTR [esp+0x4]
0x4027cc lock cmpxchg DWORD PTR [ecx], edx
0x4027d0 ret 0xc
```
This gets lifted to the following Vex:
```
...
------ IMak(0x4027cc, 4, 0) ------
t(5,4294967295) = CASle(t20 :: (t14,None)->(t17,None))
PUT(cc_op) = 0x00000006
PUT(cc_dep1) = t14
PUT(cc_dep2) = t5
...
```
Running DDG analysis generates the following error:
```
File "/angr/angr/analyses/ddg.py", line 370, in _track
    prev_code_loc = temps[a.tmp]
KeyError: 5
```
This error is occurring because the Vex statement `PUT(cc_dep2) = t5` is attempting to read from `t5`, however `t5` does not exist in the `temps` dictionary. This appears to be caused by the implementation of the CAS statement in `simuvex/simuvex/vex/statements/cas.py`.

As per the CAS statement's semantics, the `_execute` method reads the contents at `addr` and stores the value in `oldLo` via `self.state.scratch.store_tmp(self.stmt.oldLo, old_lo)`. However, this does not create a `SimActionData` object for the write to `t5`, resulting in the error above.

Instead of storing the contents at `addr` directly into the state's scratch, I _think_ the correct thing to do is to call `SimIRStmt`'s `_write_tmp` method. This both stores the tmp into the state's scratch and also records the write in a `SimActionData` object.

I've replaced `self.state.scratch.store_tmp(self.stmt.oldLo, old_lo)` with `self._write_tmp(self.stmt.oldLo, old_lo, old_lo.size(), None, None)`.

I noticed that the top of `cas.py` has a `TODO: tmp write SimActions`; is this the correct solution? It seems to be working correctly, but I want to ensure I've got all the constraints/dependencies correct. All comments appreciated!