### PR TITLE
Implement a SimProcedure __libc_init.py for Bionic libc

### DIFF
--- a/simuvex/procedures/libc___so___6/__init__.py
+++ b/simuvex/procedures/libc___so___6/__init__.py
@@ -15,4 +15,16 @@ _IO_FILE = {
         'size': 216,
         'fd': 0x70,
     },
+# Bionic libc does not use __IO_FILE
+# Refer to http://androidxref.com/5.1.1_r6/xref/bionic/libc/include/stdio.h
+# __sFILE replaces __IO_FILE
+# _file replaces _fileno
+    'ARM': {
+        'size': 84,
+        'fd': 0x0e,
+    },
+    'AARCH64': {
+        'size': 152,
+        'fd': 0x14,
+    },
 }

--- a/simuvex/procedures/libc___so___6/__libc_init.py
+++ b/simuvex/procedures/libc___so___6/__libc_init.py
@@ -1,0 +1,35 @@
+import simuvex
+
+######################################
+# __libc_init
+#
+# Refer to http://androidxref.com/5.1.1_r6/xref/bionic/libc/bionic/libc_init_dynamic.cpp
+# and http://androidxref.com/5.1.1_r6/xref/bionic/libc/private/KernelArgumentBlock.h
+# raw_args points to argc, *argv, and *envp located on the stack
+# unused is always zero
+# slingshot points to main()
+# structors points to PRE_INIT_ARRAY, INIT_ARRAY, and FINI_ARRAY
+######################################
+class __libc_init(simuvex.SimProcedure):
+    #pylint:disable=arguments-differ,unused-argument,attribute-defined-outside-init
+
+    ADDS_EXITS = True
+    NO_RET = True
+    local_vars = ('main', 'argc', 'argv', 'envp')
+
+    def run(self, raw_args, unused, slingshot, structors):
+        offset = self.state.arch.bits / 8
+        readlen = self.state.arch.bits / 8
+        endness = self.state.arch.memory_endness
+        self.main = slingshot;
+        self.argc = self.state.memory.load(raw_args + 0 * offset, readlen, endness=endness)
+        argc_val = self.state.se.any_int(self.argc)
+        self.argv = self.state.memory.load(raw_args + 1 * offset, readlen, endness=endness)
+        self.envp= self.state.memory.load(raw_args + (1 + argc_val + 1) * offset, readlen, endness=endness)
+        # TODO: __cxa_atexit calls for various at-exit needs
+        self.call(self.main, (self.argc, self.argv, self.envp), 'after_slingshot')
+
+    def after_slingshot(self, raw_args, unused, slingshot, structors, exit_addr=0):
+        self.inline_call(simuvex.SimProcedures['libc.so.6']['exit'], 0)
+
+from archinfo import ArchAMD64


### PR DESCRIPTION
Tested on the fauxware example cross-compiled for 32-bit arm Android
`export SYSROOT=$NDK/platforms/android-21/arch-arm`
`arm-linux-androideabi-gcc --sysroot=$SYSROOT -fPIE -pie -o fauxware.arm.elf fauxware.c`