### PR TITLE
Removed redundant self.ret() in Nop.run

### DIFF
--- a/simuvex/procedures/libc___so___6/perror.py
+++ b/simuvex/procedures/libc___so___6/perror.py
@@ -13,6 +13,3 @@ class perror(simuvex.SimProcedure):
 
         length = self.inline_call(strlen, string).ret_expr
         self.inline_call(write, 2, string, length)
-
-        # TODO: return values
-        self.ret()

--- a/simuvex/procedures/libc___so___6/pthread_cond_signal.py
+++ b/simuvex/procedures/libc___so___6/pthread_cond_signal.py
@@ -7,4 +7,3 @@ import simuvex
 class pthread_cond_signal(simuvex.SimProcedure):
     def run(self):
         _ = self.arg(0)
-        self.ret()

--- a/simuvex/procedures/libc___so___6/pthread_mutex_lock.py
+++ b/simuvex/procedures/libc___so___6/pthread_mutex_lock.py
@@ -7,4 +7,3 @@ import simuvex
 class pthread_mutex_lock(simuvex.SimProcedure):
     def run(self):
         _ = self.arg(0)
-        self.ret()

--- a/simuvex/procedures/libc___so___6/pthread_mutex_unlock.py
+++ b/simuvex/procedures/libc___so___6/pthread_mutex_unlock.py
@@ -7,4 +7,3 @@ import simuvex
 class pthread_mutex_unlock(simuvex.SimProcedure):
     def run(self):
         _ = self.arg(0)
-        self.ret()

--- a/simuvex/procedures/libc___so___6/strchr.py
+++ b/simuvex/procedures/libc___so___6/strchr.py
@@ -35,4 +35,4 @@ class strchr(simuvex.SimProcedure):
         return a
         #self.state.add_constraints(self.state.se.ULT(a - s_addr, s_strlen.ret_expr))
         #self.max_chr_index = max(i)
-        #self.ret(a)
+        #return a

--- a/simuvex/procedures/libc___so___6/usleep.py
+++ b/simuvex/procedures/libc___so___6/usleep.py
@@ -11,4 +11,4 @@ class usleep(simuvex.SimProcedure):
     def run(self, n): #pylint:disable=unused-argument
         self.argument_types = {0: SimTypeInt(32, False)}
         self.return_type = SimTypeInt(32, True)
-        self.ret()
+        return 0

--- a/simuvex/procedures/stubs/Nop.py
+++ b/simuvex/procedures/stubs/Nop.py
@@ -7,4 +7,4 @@ import simuvex
 
 class Nop(simuvex.SimProcedure):
     def run(self):
-        self.ret()
+        pass


### PR DESCRIPTION
The `ret` function is already called in `SimProcedure.__init__`. Calling it again voids the caller and its stack frame.
