### PR TITLE
fix memset bug

### DIFF
--- a/simuvex/procedures/libc___so___6/memset.py
+++ b/simuvex/procedures/libc___so___6/memset.py
@@ -60,7 +60,7 @@ class memset(simuvex.SimProcedure):
             if char._model_concrete.value == 0:
                 write_bytes = self.state.se.BVV(0, max_size * 8)
             else:
-                rb = memset._repeat_bytes(char._model_concrete.value, max_size * 8)
+                rb = memset._repeat_bytes(char._model_concrete.value, max_size)
                 write_bytes = self.state.se.BVV(rb, max_size * 8)
             self.state.memory.store(dst_addr, write_bytes)
 


### PR DESCRIPTION
following a call to `memset(buf, 0x41, 8)`

`In [1]: buf`
`Out[1]: <BV32 0xc0000c20>`
`In [2]: buf_bytes7 = results.found[0].state.memory.load(buf, 7)`
`In [3]: buf_bytes8 = results.found[0].state.memory.load(buf, 8)`
`In [4]: print buf_bytes7`
`<BV56 0x41414141414141>`
`In [5]: print buf_bytes8`
`<BV64 0x41414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141>`