### PR TITLE
Fix recvfrom

### DIFF
--- a/simuvex/procedures/libc___so___6/recvfrom.py
+++ b/simuvex/procedures/libc___so___6/recvfrom.py
@@ -8,6 +8,5 @@ class recvfrom(simuvex.SimProcedure):
     #pylint:disable=arguments-differ
 
     def run(self, fd, dst, length, flags): #pylint:disable=unused-argument
-        data = self.state.posix.read(fd, length)
-        self.state.memory.store(dst, data)
-        return length
+        bytes_recvd = self.state.posix.read(fd, dst, self.state.se.any_int(length))
+        return bytes_recvd


### PR DESCRIPTION
posix.read() takes exactly 4 arguments
original fix was proposed by Yiming Jing

Original pull-request was #21, but original author seems to be inactive