### PR TITLE
fix of PPC 32bit syscall calling convention + some PEP8 fixes

### DIFF
--- a/simuvex/s_cc.py
+++ b/simuvex/s_cc.py
@@ -910,7 +910,7 @@ class SimCCPowerPC(SimCC):
 
 class SimCCPowerPCLinuxSyscall(SimCC):
     # TODO: Make sure all the information is correct
-    ARG_REGS = [ ]
+    ARG_REGS = ['r3', 'r4', 'r5', 'r6', 'r7', 'r8', 'r9', 'r10']
     FP_ARG_REGS = [ ]
     RETURN_VAL = SimRegArg('r3', 4)
     ARCH = ArchPPC32


### PR DESCRIPTION
fix of PPC 32bit syscall calling convention.
this should work fine for syscalls, but PPC calling convention appears to be quite more complex [http://web.archive.org/web/20110726065225/http://refspecs.freestandards.org/elf/elfspec_ppc.pdf]
with return values in r3/r4 and f1/f4 (if the function returns a float).

Also fixed some PEP8 violations, where i noticed that the code used these conventions at first (i.e. 2 empty lines before class/func declaration) and then don't use them anymore later.