### PR TITLE
Use type environment for result information

### DIFF
--- a/simuvex/vex/expressions/__init__.py
+++ b/simuvex/vex/expressions/__init__.py
@@ -1,4 +1,4 @@
-def translate_expr(expr, imark, stmt_idx, state):
+def translate_expr(expr, imark, stmt_idx, tyenv, state):
     expr_name = 'SimIRExpr_' + type(expr).__name__.split('IRExpr')[-1].split('.')[-1]
     g = globals()
 
@@ -10,7 +10,7 @@ def translate_expr(expr, imark, stmt_idx, state):
         expr_class = g[expr_name]
 
     l.debug("Processing expression %s", expr_name)
-    e = expr_class(expr, imark, stmt_idx, state)
+    e = expr_class(expr, imark, stmt_idx, tyenv, state)
     e.process()
     return e
 

--- a/simuvex/vex/expressions/base.py
+++ b/simuvex/vex/expressions/base.py
@@ -7,11 +7,12 @@ l = logging.getLogger("simuvex.vex.expressions.base")
 _nonset = frozenset()
 
 class SimIRExpr(object):
-    def __init__(self, expr, imark, stmt_idx, state):
+    def __init__(self, expr, imark, stmt_idx, tyenv, state):
         self.state = state
         self._constraints = [ ]
         self.imark = imark
         self.stmt_idx = stmt_idx
+        self.tyenv = tyenv
         self.child_exprs = [ ]
 
         # effects tracking
@@ -25,7 +26,7 @@ class SimIRExpr(object):
         if expr.tag in ('Iex_BBPTR', 'Iex_VECRET'):
             self.type = None
         else:
-            self.type = expr.result_type
+            self.type = expr.result_type(self.tyenv)
 
         self.state._inspect('expr', BP_BEFORE)
 
@@ -72,7 +73,7 @@ class SimIRExpr(object):
 
     def _translate_expr(self, expr):
         """Translate a single IRExpr, honoring mode and options and so forth. Also updates state..."""
-        e = translate_expr(expr, self.imark, self.stmt_idx, self.state)
+        e = translate_expr(expr, self.imark, self.stmt_idx, self.tyenv, self.state)
         self._record_expr(e)
         self.child_exprs.append(e)
         return e

--- a/simuvex/vex/irsb.py
+++ b/simuvex/vex/irsb.py
@@ -116,7 +116,7 @@ class SimIRSB(SimRun):
             l.debug("%s adding default exit.", self)
 
             try:
-                self.next_expr = translate_expr(self.irsb.next, self.last_imark, self.num_stmts, self.state)
+                self.next_expr = translate_expr(self.irsb.next, self.last_imark, self.num_stmts, self.irsb.tyenv, self.state)
 
                 self.state.log.extend_actions(self.next_expr.actions)
 
@@ -235,7 +235,7 @@ class SimIRSB(SimRun):
             # that we can continue on. Otherwise, add the constraints
             if type(stmt) == pyvex.IRStmt.Exit:
                 l.debug("%s adding conditional exit", self)
-
+                
                 e = self.add_successor(self.state.copy(), s_stmt.target, s_stmt.guard, s_stmt.jumpkind, stmt_idx)
                 self.conditional_exits.append(e)
                 self.state.add_constraints(self.state.se.Not(s_stmt.guard))

--- a/simuvex/vex/statements/base.py
+++ b/simuvex/vex/statements/base.py
@@ -33,7 +33,7 @@ class SimIRStmt(object):
 
     def _translate_expr(self, expr):
         """Translates an IRExpr into a SimIRExpr."""
-        e = translate_expr(expr, self.imark, self.stmt_idx, self.state)
+        e = translate_expr(expr, self.imark, self.stmt_idx, self.irsb.tyenv, self.state)
         self._record_expr(e)
         return e
 

--- a/simuvex/vex/statements/wrtmp.py
+++ b/simuvex/vex/statements/wrtmp.py
@@ -7,6 +7,6 @@ class SimIRStmt_WrTmp(SimIRStmt):
         self._write_tmp(self.stmt.tmp, data.expr, data.size_bits(), data.reg_deps(), data.tmp_deps())
 
         actual_size = data.size_bits()
-        expected_size = self.stmt.data.result_size
+        expected_size = self.stmt.data.result_size(self.irsb.tyenv)
         if actual_size != expected_size:
             raise SimStatementError("WrTmp expected length %d but got %d" % (actual_size, expected_size))


### PR DESCRIPTION
Changes to support the IRExpr `result_type` and `result_size` attributes in pyvex becoming methods which take the type environment as an argument. 

The pull request which changes `result_type` and `result_size` can be found here: angr/pyvex#51