### PR TITLE
Fixed an unit error on checking if a page already exists at the specified addresss in `SimPagedMemory.map_region`

### DIFF
--- a/simuvex/storage/paged_memory.py
+++ b/simuvex/storage/paged_memory.py
@@ -812,7 +812,7 @@ class SimPagedMemory(object):
         if self.state.mode != 'fastpath':
             for page in xrange(pages):
                 page_id = base_page_num + page
-                if page_id in self:
+                if (page_id * self._page_size) in self:
                     l.warning("map_page received address and length combination which contained mapped page")
                     return
 

--- a/simuvex/storage/paged_memory.py
+++ b/simuvex/storage/paged_memory.py
@@ -812,7 +812,7 @@ class SimPagedMemory(object):
         if self.state.mode != 'fastpath':
             for page in xrange(pages):
                 page_id = base_page_num + page
-                if (page_id * self._page_size) in self:
+                if page_id * self._page_size in self:
                     l.warning("map_page received address and length combination which contained mapped page")
                     return
 


### PR DESCRIPTION
Found this bug while running random stuffs with paging check enabled :p
The `SimPagedMemory` accepts actual virtual address as its index, but the old code used the page offset to check it.