### PR TITLE
Fix repr of fixed length array

### DIFF
--- a/simuvex/s_type.py
+++ b/simuvex/s_type.py
@@ -371,7 +371,7 @@ class SimTypeFixedSizeArray(SimType):
         return view._deeper(addr=view._addr + k * self.elem_type.size, ty=self.elem_type)
 
     def extract(self, state, addr, concrete=False):
-        return [self.elem_type.extract(state, addr + i*self.elem_type.size, concrete) for i in xrange(self.length)]
+        return [self.elem_type.extract(state, addr + i*(self.elem_type.size/8), concrete) for i in xrange(self.length)]
 
     def store(self, state, addr, values):
         for i, val in enumerate(values):


### PR DESCRIPTION
So while playing around with the s_type functionality (very cool btw), i found what appears to be a bug. In short, when asking for a repr for a fixedlengtharray object, in this case the array was made up of char objects, it did not display correctly. The code appears to save the size of the character object in bits, but then reference offset to display in bytes. This causes it to only actually display every 8th char.

Attaching my test binary.
[a.zip](https://github.com/angr/simuvex/files/679952/a.zip)


Source code is:
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

typedef struct {
    int x;
    int y;
    char z[128];
} myStruct;

int main() {

    myStruct x = {};

    x.x = 1;
    x.y = 2;
    strcpy(x.z,"Hello!");

    printf(x.z);
    return 0;
}
```

Test python script is:
```python
import angr, simuvex

proj = angr.Project("./a.out")

state = proj.factory.full_init_state(remove_options={simuvex.o.LAZY_SOLVES})

pg = proj.factory.path_group(state)

pg.explore(find=0x00400783)

s = pg.found[0].state.copy()

simuvex.s_type.define_struct("""struct myStruct {
    int x;
    int y;
    char z[128];
}
""")


m = s.mem[s.regs.rbp-0x90].myStruct

m.z
```

Admittedly, I have only tested this change against my situation, but it would stand to reason it should work on other test cases.

Also, doing "m.z.string" doesn't work, though I'm not sure if it is supposed to. At least the character array representation shows correctly now.