### PR TITLE
Stubbing out mprotect

### DIFF
--- a/simuvex/procedures/syscalls/mprotect.py
+++ b/simuvex/procedures/syscalls/mprotect.py
@@ -1,0 +1,10 @@
+import simuvex
+
+class mprotect(simuvex.SimProcedure):
+
+    IS_SYSCALL = True
+
+    def run(self, addr, length, prot): #pylint:disable=arguments-differ,unused-argument
+
+        # TODO: Actually handle this syscall
+        return self.state.se.BVV(0, self.state.arch.bits)


### PR DESCRIPTION
Stubbing this syscall out for the malloc example I want to post. Always returning 0 allows us to assume success and cover the major cases, though it needs to be fleshed out in the future.