### PR TITLE
Copying mmap_base in libc

### DIFF
--- a/simuvex/plugins/libc.py
+++ b/simuvex/plugins/libc.py
@@ -220,6 +220,7 @@ class SimStateLibc(SimStatePlugin):
     def copy(self):
         c = SimStateLibc()
         c.heap_location = self.heap_location
+        c.mmap_base = self.mmap_base
         c.buf_symbolic_bytes = self.buf_symbolic_bytes
         c.max_symbolic_strstr = self.max_symbolic_strstr
         c.max_symbolic_strchr = self.max_symbolic_strchr

--- a/tests/syscalls/test_mmap.py
+++ b/tests/syscalls/test_mmap.py
@@ -1,5 +1,4 @@
 import nose
-import archinfo
 import simuvex
 
 import logging

--- a/tests/syscalls/test_mmap.py
+++ b/tests/syscalls/test_mmap.py
@@ -1,0 +1,28 @@
+import nose
+import archinfo
+import simuvex
+
+import logging
+l = logging.getLogger('simuvex.syscalls.mmap')
+
+
+def test_mmap_base_copy():
+    state = simuvex.SimState(arch="AMD64", mode="symbolic")
+
+    mmap_base = 0x12345678
+
+    state.libc.mmap_base = mmap_base
+
+    # Sanity check
+    nose.tools.assert_equal(state.libc.mmap_base, mmap_base)
+
+    state_copy = state.copy()
+
+    nose.tools.assert_equal(state_copy.libc.mmap_base, mmap_base)
+
+
+if __name__ == '__main__':
+    g = globals().copy()
+    for func_name, func in g.iteritems():
+        if func_name.startswith("test_") and hasattr(func, "__call__"):
+            func()


### PR DESCRIPTION
This was a bit of a PITA to find. Execution wasn't working quite right because every time state split we'd lose track of the mmap_base address.