### PR TITLE
Fixed return value of unlink

### DIFF
--- a/simuvex/procedures/syscalls/unlink.py
+++ b/simuvex/procedures/syscalls/unlink.py
@@ -19,4 +19,4 @@ class unlink(simuvex.SimProcedure): #pylint:disable=W0622
 
         ret = self.state.posix.remove(str_val)
 
-        return self.state.se.BVV(ret, 64)
+        return self.state.se.BVV(ret, self.state.arch.bits)


### PR DESCRIPTION
Generation of CFG via `CFGAccurate(keep_state=True)` resulted in `TypeError: <BV64 0x0> doesn't fit in an argument of size 4`