### PR TITLE
Add _op_Iop_QNarrowBin16Sto8Ux16 for PACKUSWB xmm1, xmm2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - PY=p ANGR_REPO=colorguard
   - PY=e ANGR_REPO=fidget
   - PY=e ANGR_REPO=patcherex
-  - PY=e ANGR_REPO=identifier
   - PY=e ANGR_REPO=tracer NOSE_OPTIONS="--process-timeout=900"
 #  - PY=p ANGR_REPO=rex NOSE_OPTIONS="-x" NOSE_PROCESSES=1
 install: ( curl https://raw.githubusercontent.com/angr/angr-dev/$TRAVIS_BRANCH/tests/travis-install.sh | grep -v 404 || curl https://raw.githubusercontent.com/angr/angr-dev/master/tests/travis-install.sh ) | bash

--- a/simuvex/engines/vex/irop.py
+++ b/simuvex/engines/vex/irop.py
@@ -791,7 +791,7 @@ class SimIROp(object):
                     result = self._op_concat((result, dst_value))
         return result
 
-    def _op_generic_StoU_saturation(self, value, min_value, max_value):
+    def _op_generic_StoU_saturation(self, value, min_value, max_value): #pylint:disable=no-self-use
         """
         Return unsigned saturated BV from signed BV.
         Min and max value should be unsigned.

--- a/simuvex/engines/vex/irop.py
+++ b/simuvex/engines/vex/irop.py
@@ -769,9 +769,36 @@ class SimIROp(object):
             rm = self._translate_rm(args[0])
             rounded_bv = claripy.fpToSBV(rm, args[1].raw_to_fp(), args[1].length)
             return claripy.fpToFP(claripy.fp.RM_RNE, rounded_bv, claripy.fp.FSort.from_size(args[1].length))
-
+    
+    def _op_generic_pack_StoU_saturation(self, args, src_size, dst_size):
+    """
+    Generic pack with unsigned saturation.
+    Split args in chunks of src_size signed bits and in pack them into unsigned saturated chunks of dst_size bits.
+    Then chunks are concatenated resulting in a BV of len(args)*dst_size/src_size*len(args[0]) bits.
+    """
+        if src_size <= 0 or dst_size <= 0:
+            raise SimOperationError("Can't pack from or to zero or negative size" % self.name)
+        result = None
+        max_value = (2 << dst_size-1)-1 #max value for unsigned saturation, equivalement to pow(2, dst_size)-1, sizes can't be 0
+        for v in args:
+            for src_value in v.chop(src_size):
+                saturated_value = claripy.bv.BVV(src_value.args[0], src_value.args[1]).signed #best way to get the signed value of a claripy.ast.bv.BV?
+                saturated_value = SimIROp.saturate(saturated_value, 0, max_value)
+                dst_value = claripy.BVV(saturated_value, dst_size)
+                if result is None:
+                    result = dst_value
+                else:
+                    result = self._op_concat((result, dst_value))
+        return result
+    
     def _op_Iop_64x4toV256(self, args) :
         return self._op_concat(args)
+        
+    def _op_Iop_QNarrowBin16Sto8Ux16(self, args):
+    """
+    PACKUSWB Pack with Unsigned Saturation. Two 128 bits operands version (66 0F 67...).
+    """
+        return self._op_generic_pack_StoU_saturation(args, 16, 8)
 
     #def _op_Iop_Yl2xF64(self, args):
     #   rm = self._translate_rm(args[0])
@@ -802,6 +829,17 @@ class SimIROp(object):
         for _ in xrange(n):
             out = claripy.fpMul(rm, arg, out)
         return out
+    
+    @staticmethod
+    def saturate(value, min_value, max_value):
+    """
+    Generic saturation on numbers.
+    """
+        if value > max_value:
+            return max_value
+        if value < min_value:
+            return min_value
+        return value
 
     #def _op_Iop_SinF64(self, args):
     #   rm, arg = args

--- a/simuvex/engines/vex/irop.py
+++ b/simuvex/engines/vex/irop.py
@@ -790,10 +790,10 @@ class SimIROp(object):
                 else:
                     result = self._op_concat((result, dst_value))
         return result
-    
+
     def _op_Iop_64x4toV256(self, args) :
         return self._op_concat(args)
-        
+
     def _op_Iop_QNarrowBin16Sto8Ux16(self, args):
         """
         PACKUSWB Pack with Unsigned Saturation. Two 128 bits operands version (66 0F 67...).
@@ -829,7 +829,7 @@ class SimIROp(object):
         for _ in xrange(n):
             out = claripy.fpMul(rm, arg, out)
         return out
-    
+
     @staticmethod
     def saturate(value, min_value, max_value):
         """

--- a/simuvex/engines/vex/irop.py
+++ b/simuvex/engines/vex/irop.py
@@ -769,7 +769,7 @@ class SimIROp(object):
             rm = self._translate_rm(args[0])
             rounded_bv = claripy.fpToSBV(rm, args[1].raw_to_fp(), args[1].length)
             return claripy.fpToFP(claripy.fp.RM_RNE, rounded_bv, claripy.fp.FSort.from_size(args[1].length))
-    
+
     def _op_generic_pack_StoU_saturation(self, args, src_size, dst_size):
     """
     Generic pack with unsigned saturation.

--- a/simuvex/engines/vex/irop.py
+++ b/simuvex/engines/vex/irop.py
@@ -771,11 +771,11 @@ class SimIROp(object):
             return claripy.fpToFP(claripy.fp.RM_RNE, rounded_bv, claripy.fp.FSort.from_size(args[1].length))
 
     def _op_generic_pack_StoU_saturation(self, args, src_size, dst_size):
-    """
-    Generic pack with unsigned saturation.
-    Split args in chunks of src_size signed bits and in pack them into unsigned saturated chunks of dst_size bits.
-    Then chunks are concatenated resulting in a BV of len(args)*dst_size/src_size*len(args[0]) bits.
-    """
+        """
+        Generic pack with unsigned saturation.
+        Split args in chunks of src_size signed bits and in pack them into unsigned saturated chunks of dst_size bits.
+        Then chunks are concatenated resulting in a BV of len(args)*dst_size/src_size*len(args[0]) bits.
+        """
         if src_size <= 0 or dst_size <= 0:
             raise SimOperationError("Can't pack from or to zero or negative size" % self.name)
         result = None
@@ -795,9 +795,9 @@ class SimIROp(object):
         return self._op_concat(args)
         
     def _op_Iop_QNarrowBin16Sto8Ux16(self, args):
-    """
-    PACKUSWB Pack with Unsigned Saturation. Two 128 bits operands version (66 0F 67...).
-    """
+        """
+        PACKUSWB Pack with Unsigned Saturation. Two 128 bits operands version (66 0F 67...).
+        """
         return self._op_generic_pack_StoU_saturation(args, 16, 8)
 
     #def _op_Iop_Yl2xF64(self, args):
@@ -832,9 +832,9 @@ class SimIROp(object):
     
     @staticmethod
     def saturate(value, min_value, max_value):
-    """
-    Generic saturation on numbers.
-    """
+        """
+        Generic saturation on numbers.
+        """
         if value > max_value:
             return max_value
         if value < min_value:

--- a/simuvex/engines/vex/irop.py
+++ b/simuvex/engines/vex/irop.py
@@ -779,24 +779,41 @@ class SimIROp(object):
         if src_size <= 0 or dst_size <= 0:
             raise SimOperationError("Can't pack from or to zero or negative size" % self.name)
         result = None
-        max_value = (2 << dst_size-1)-1 #max value for unsigned saturation, equivalement to pow(2, dst_size)-1, sizes can't be 0
+        max_value = claripy.BVV(-1, dst_size).zero_extend(src_size - dst_size) #max value for unsigned saturation
+        min_value = claripy.BVV(0, src_size) #min unsigned value always 0
         for v in args:
             for src_value in v.chop(src_size):
-                saturated_value = claripy.bv.BVV(src_value.args[0], src_value.args[1]).signed #best way to get the signed value of a claripy.ast.bv.BV?
-                saturated_value = SimIROp.saturate(saturated_value, 0, max_value)
-                dst_value = claripy.BVV(saturated_value, dst_size)
+                dst_value = self._op_generic_StoU_saturation(src_value, min_value, max_value)
+                dst_value = dst_value.zero_extend(dst_size - src_size)
                 if result is None:
                     result = dst_value
                 else:
                     result = self._op_concat((result, dst_value))
         return result
 
+    def _op_generic_StoU_saturation(self, value, min_value, max_value):
+        """
+        Return unsigned saturated BV from signed BV.
+        Min and max value should be unsigned.
+        """
+        return claripy.If(
+            claripy.SGT(value, max_value),
+            max_value,
+            claripy.If(claripy.SLT(value, min_value), min_value, value))
+
     def _op_Iop_64x4toV256(self, args) :
         return self._op_concat(args)
 
     def _op_Iop_QNarrowBin16Sto8Ux16(self, args):
         """
-        PACKUSWB Pack with Unsigned Saturation. Two 128 bits operands version (66 0F 67...).
+        PACKUSWB Pack with Unsigned Saturation.Two 128 bits operands version.
+        VPACKUSWB Pack with Unsigned Saturation.Three 128 bits operands version.
+        """
+        return self._op_generic_pack_StoU_saturation(args, 16, 8)
+
+    def _op_Iop_QNarrowBin16Sto8Ux8(self, args):
+        """
+        PACKUSWB Pack with Unsigned Saturation.Two 64 bits operands version.
         """
         return self._op_generic_pack_StoU_saturation(args, 16, 8)
 
@@ -829,17 +846,6 @@ class SimIROp(object):
         for _ in xrange(n):
             out = claripy.fpMul(rm, arg, out)
         return out
-
-    @staticmethod
-    def saturate(value, min_value, max_value):
-        """
-        Generic saturation on numbers.
-        """
-        if value > max_value:
-            return max_value
-        if value < min_value:
-            return min_value
-        return value
 
     #def _op_Iop_SinF64(self, args):
     #   rm, arg = args

--- a/simuvex/procedures/syscalls/arch_prctl.py
+++ b/simuvex/procedures/syscalls/arch_prctl.py
@@ -33,3 +33,4 @@ class arch_prctl(simuvex.SimProcedure):
         else:
             #EINVAL is returned if code is not a valid subcommand.
             return 22
+        return 0

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -169,7 +169,7 @@ def test_some_vector_ops():
     calc_result = translate(s, 'Iop_Min8Sx16', (a, b))
     correct_result = s.se.BVV(0xffff0000000100020002000200020002, 128)
     nose.tools.assert_true(s.se.is_true(calc_result == correct_result))
-    
+
     calc_result = translate(s, 'Iop_QNarrowBin16Sto8Ux16', (a, b))
     correct_result = s.se.BVV(0x00000102030405060202020202020202, 128)
     nose.tools.assert_true(s.se.is_true(calc_result == correct_result))

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -169,6 +169,10 @@ def test_some_vector_ops():
     calc_result = translate(s, 'Iop_Min8Sx16', (a, b))
     correct_result = s.se.BVV(0xffff0000000100020002000200020002, 128)
     nose.tools.assert_true(s.se.is_true(calc_result == correct_result))
+    
+    calc_result = translate(s, 'Iop_QNarrowBin16Sto8Ux16', (a, b))
+    correct_result = s.se.BVV(0x00000102030405060202020202020202, 128)
+    nose.tools.assert_true(s.se.is_true(calc_result == correct_result))
 
     c =              s.se.BVV(0xff008877, 32)
     d =              s.se.BVV(0x11111111, 32)


### PR DESCRIPTION
This only adds support for the PACKUSWB instruction with two 128 bits operands but there is a generic function for other versions of PACKUSWB (and maybe other stuff).

Edit: actually supports also VPACKUSWB xmm1, xmm2, xmm3 (basically the same instruction)