### PR TITLE
Passing memory endness info from SimState to SimMemory

### DIFF
--- a/simuvex/s_state.py
+++ b/simuvex/s_state.py
@@ -86,11 +86,11 @@ class SimState(ana.Storable): # pylint: disable=R0904
                     memory_backer = {'global': memory_backer}
 
                 # TODO: support permissions backer in SimAbstractMemory
-                self.register_plugin('memory', SimAbstractMemory(memory_backer=memory_backer, memory_id="mem"))
+                self.register_plugin('memory', SimAbstractMemory(memory_backer=memory_backer, memory_id="mem", endness=self.arch.memory_endness))
             elif o.FAST_MEMORY in self.options:
-                self.register_plugin('memory', SimFastMemory(memory_backer=memory_backer, memory_id="mem"))
+                self.register_plugin('memory', SimFastMemory(memory_backer=memory_backer, memory_id="mem", endness=self.arch.memory_endness))
             else:
-                self.register_plugin('memory', SimSymbolicMemory(memory_backer=memory_backer, permissions_backer=permissions_backer, memory_id="mem"))
+                self.register_plugin('memory', SimSymbolicMemory(memory_backer=memory_backer, permissions_backer=permissions_backer, memory_id="mem", endness=self.arch.memory_endness))
         if not self.has_plugin('registers'):
             if o.FAST_REGISTERS in self.options:
                 self.register_plugin('registers', SimFastMemory(memory_id="reg", endness=self.arch.register_endness))


### PR DESCRIPTION
The default endness of SimMemory is "Iend_BE", it won't pass the arch endness info to SimMemory in original code.