### PR TITLE
Format strings: Add ssize to s_type, change ptrdiff_t to signed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - PY=p ANGR_REPO=colorguard
   - PY=e ANGR_REPO=fidget
   - PY=e ANGR_REPO=patcherex
-  - PY=e ANGR_REPO=identifier
   - PY=e ANGR_REPO=tracer NOSE_OPTIONS="--process-timeout=900"
 #  - PY=p ANGR_REPO=rex NOSE_OPTIONS="-x" NOSE_PROCESSES=1
 install: ( curl https://raw.githubusercontent.com/angr/angr-dev/$TRAVIS_BRANCH/tests/travis-install.sh | grep -v 404 || curl https://raw.githubusercontent.com/angr/angr-dev/master/tests/travis-install.sh ) | bash

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
 
 setup(
     name='simuvex',
-    version='6.7.6.9',
+    version='6.7.7.27',
     description=' A symbolic execution engine for the VEX IR',
     url='https://github.com/angr/simuvex',
     packages=packages,

--- a/simuvex/procedures/syscalls/arch_prctl.py
+++ b/simuvex/procedures/syscalls/arch_prctl.py
@@ -33,3 +33,4 @@ class arch_prctl(simuvex.SimProcedure):
         else:
             #EINVAL is returned if code is not a valid subcommand.
             return 22
+        return 0

--- a/simuvex/s_format.py
+++ b/simuvex/s_format.py
@@ -255,7 +255,7 @@ class FormatParser(SimProcedure):
 
         # FIXME: intmax_t seems to be always 64 bit, but not too sure
         'j' : ('int64_t', 'uint64_t'),
-        'z' : ('ssize', 'size_t'), # TODO: implement in s_type
+        'z' : ('ssize', 'size_t'),
         't' : ('ptrdiff_t', 'ptrdiff_t'), # TODO: implement in s_type
     }
 

--- a/simuvex/s_format.py
+++ b/simuvex/s_format.py
@@ -256,7 +256,7 @@ class FormatParser(SimProcedure):
         # FIXME: intmax_t seems to be always 64 bit, but not too sure
         'j' : ('int64_t', 'uint64_t'),
         'z' : ('ssize', 'size_t'),
-        't' : ('ptrdiff_t', 'ptrdiff_t'), # TODO: implement in s_type
+        't' : ('ptrdiff_t', 'ptrdiff_t'), 
     }
 
     # Types that are not known by Simuvex.s_types

--- a/simuvex/s_type.py
+++ b/simuvex/s_type.py
@@ -718,8 +718,8 @@ ALL_TYPES = {
     'ptrdiff_t': SimTypeLong(False),
     'size_t': SimTypeLength(False),
     'ssize_t': SimTypeLength(True),
-    'uintptr_t' : SimTypeLong(False),
-
+    'ssize': SimTypeLength(False),
+    'uintptr_t': SimTypeLong(False),
     'string': SimTypeString(),
 }
 

--- a/simuvex/s_type.py
+++ b/simuvex/s_type.py
@@ -715,7 +715,7 @@ ALL_TYPES = {
     'uint64_t': SimTypeNum(64, False),
     'qword': SimTypeNum(64, False),
 
-    'ptrdiff_t': SimTypeLong(False),
+    'ptrdiff_t': SimTypeLong(True),
     'size_t': SimTypeLength(False),
     'ssize_t': SimTypeLength(True),
     'ssize': SimTypeLength(False),


### PR DESCRIPTION
I needed support for %td and %zd. These were already implemented in s_format so I added them to s_type. I also noticed that ptrdiff_t was set to unsigned for some reason. 